### PR TITLE
Exclude .exe files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# .exe files
+*.exe


### PR DESCRIPTION
fix, feature. Added a line in the .gitignore to exclude .exe files from version control.